### PR TITLE
made header logo smaller, renamed first nav item to 'home'

### DIFF
--- a/src/pages/KSPage.tsx
+++ b/src/pages/KSPage.tsx
@@ -34,18 +34,17 @@ export const wrapSection  = (section : any, props?: {isFilled ?: boolean, noPadd
  * @param props.sidebar content to render within page sidebar
  */
 export const KSPage : React.FunctionComponent<KSPProps> = (props: KSPProps) => {
-
-    const brand = <Brand src={Scout_Cloud2} alt="KScout.io"></Brand>
+    const brand = <Brand className="ks-topbar__brand" src={Scout_Cloud2} alt="KScout.io" />;
 
     const logoProps = {
-        src: Scout_Cloud2, 
-        href: "/"
+        src: Scout_Cloud2,
+	href: "/",
     }
 
     const NavBar = ( <Nav className="ks-topbar__nav">
         <NavList variant={NavVariants.horizontal}>
-            <NavItem className="ks-topbar__nav__item ks-topbar__nav__title">
-                <Link to="/">KScout.io</Link>
+	    <NavItem className="ks-topbar__nav__item">
+                <Link to="/">Home</Link>
             </NavItem>
             <NavItem className="ks-topbar__nav__item">
                 <Link to="/apps">Apps</Link>
@@ -63,9 +62,9 @@ export const KSPage : React.FunctionComponent<KSPProps> = (props: KSPProps) => {
                 Scout Chat
             </Button>
             {isChatOpen? 
-                <div className="ks-topbar__chat__window">
-                    <ChatBot/>
-                </div> : ''
+             <div className="ks-topbar__chat__window">
+                 <ChatBot/>
+             </div> : ''
             }
         </div>
     );
@@ -91,17 +90,17 @@ export const KSPage : React.FunctionComponent<KSPProps> = (props: KSPProps) => {
 
     return (
         <Page header={Header}
-            sidebar={props.sidebar}
+              sidebar={props.sidebar}
         >
             
             {props.components.map((c,index) => {
-            return (
-                <PageSection key={index} isFilled={c.isFilled} noPadding={c.noPadding} children={c.component}/>
-            )})}
+		return (
+                    <PageSection key={index} isFilled={c.isFilled} noPadding={c.noPadding} children={c.component}/>
+		)})}
 
             {Footer}
             
-    
+	    
         </Page>
     );
 }

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -2,12 +2,22 @@
     background: linear-gradient(to right, #820000, #a30000);
     overflow: visible;
 
+    &__brand {
+	max-width: 70px;
+    }
+
     &__nav {
         
         &__item {
             --pf-c-nav__horizontal-list-link--hover--after--BackgroundColor: white;
             --pf-c-nav__horizontal-list-link--focus--after--BackgroundColor: white;
             --pf-c-nav__horizontal-list-link--active--after--BackgroundColor: white;
+
+	    a {
+		font-weight: bold !important;
+		color: white !important;
+	    }
+
             :hover {
                 color: white !important;
             }


### PR DESCRIPTION
Before change:

![2019-07-24-13-03-57](https://user-images.githubusercontent.com/3323504/61813363-86c24100-ae13-11e9-85e4-e28af96bbe8e.png)
*(Note: Ignore misaligned kscout chat button, unrelated to this PR)*

After change:

![2019-07-24-13-03-24](https://user-images.githubusercontent.com/3323504/61813343-77db8e80-ae13-11e9-819f-270dfcf5860b.png)

Change log:

- Made header logo smaller
- Renamed "KScout.io" menu item to "Home"
- Made menu items bold and brighter white